### PR TITLE
Fix wb-rules restart (#36114)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildDebArchAll()

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-dac (1.1.2) stable; urgency=medium
+
+  * use deb-systemd-invoke restart wb-rules instead of service wb-rules
+    restart to build rootfs properly after removing wb-rules initscript
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 31 May 2021 23:42:58 +0300
+
 wb-mqtt-dac (1.1.1) stable; urgency=medium
 
   * fixes config name

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-service wb-rules restart
+deb-systemd-invoke restart wb-rules
 #DEBHELPER#
 
 exit 0


### PR DESCRIPTION
Старый скрипт падает в сочетании с wb-rules 2.7.0, где вместо init-скрипта сервис systemd