### PR TITLE
If config contains both iio_device and iio_of_name properties, iio_of_name is used

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-dac (1.1.6) stable; urgency=medium
+
+  * If config contains both iio_device and iio_of_name properties, iio_of_name is used. 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 26 Apr 2022 17:36:36 +0500
+
 wb-mqtt-dac (1.1.5) stable; urgency=medium
 
   * iio_device property validation error is fixed

--- a/wb-mqtt-dac.schema.json
+++ b/wb-mqtt-dac.schema.json
@@ -53,6 +53,12 @@
                                     "type": "integer",
                                     "title": "IIO device number",
                                     "propertyOrder": 4
+                                },
+                                "iio_of_name": { 
+                                    "not" : {},
+                                    "options": {
+                                        "hidden": true
+                                    }
                                 }
                             },
                             "required": [
@@ -79,6 +85,12 @@
                                     "type": "string",
                                     "title": "IIO device name",
                                     "propertyOrder": 4
+                                },
+                                "iio_device": {
+                                    "type": "integer",
+                                    "options": {
+                                        "hidden": true
+                                    }
                                 }
                             },
                             "required": [


### PR DESCRIPTION
Клиенты пишут в конфиг одновременно iio_device и iio_of_name. В прошлой схеме то считалось ошибкой. Сейчас - нет. Приоритет у iio_of_name.