### PR TITLE
do not print error message if wb-mqtt-dac does not exist

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-dac (1.2.1) stable; urgency=medium
+
+  * do not print error message if wb-mqtt-dac.conf file does not exist
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 30 Jan 2023 15:58:38 +0600
+
 wb-mqtt-dac (1.2.0) stable; urgency=medium
 
   * Support for wb-hwconf-manager 1.51.0 is added.

--- a/debian/control
+++ b/debian/control
@@ -7,5 +7,5 @@ Build-Depends: debhelper (>= 9)
 
 Package: wb-mqtt-dac
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, wb-rules
+Depends: ${shlibs:Depends}, ${misc:Depends}, wb-rules (>= 2.18.1~~)
 Description: wb-rules-based IIO DAC driver for WB MQTT

--- a/wb-mqtt-dac.js
+++ b/wb-mqtt-dac.js
@@ -9,9 +9,9 @@
 
     var config = {};
     try {
-      config = readConfig("/var/lib/wb-mqtt-dac/conf.d/system.conf");
+      config = readConfig("/var/lib/wb-mqtt-dac/conf.d/system.conf", {"logErrorOnNoFile": false});
     } catch (err) {
-      config = readConfig("/etc/wb-mqtt-dac.conf");
+      config = readConfig("/etc/wb-mqtt-dac.conf", {"logErrorOnNoFile": false});
     }
 
     var channels_by_id = {};


### PR DESCRIPTION
Related with https://github.com/wirenboard/wb-rules/pull/86