### PR TITLE
Do not init if config file not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,8 @@ all:
 	-@echo do nothing
 
 install:
-	mkdir -p $(DESTDIR)/usr/share/wb-rules-system/rules/
 	install -d $(DESTDIR)/var/lib/wb-mqtt-dac/conf.d
-	install -m 0644 wb-mqtt-dac.js $(DESTDIR)/usr/share/wb-rules-system/rules/
+	install -Dm0644 wb-mqtt-dac.js -t $(DESTDIR)/usr/share/wb-rules-system/rules/
 
 clean:
 	-@echo "do nothing"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+## IIO DAC driver for WB MQTT

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-dac (1.2.2) stable; urgency=medium
+
+  * Do not init if config file not found
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 19 Apr 2023 17:10:00 +0400
+
 wb-mqtt-dac (1.2.1) stable; urgency=medium
 
   * do not print error message if wb-mqtt-dac.conf file does not exist

--- a/wb-mqtt-dac.js
+++ b/wb-mqtt-dac.js
@@ -11,7 +11,12 @@
     try {
       config = readConfig("/var/lib/wb-mqtt-dac/conf.d/system.conf", {"logErrorOnNoFile": false});
     } catch (err) {
-      config = readConfig("/etc/wb-mqtt-dac.conf", {"logErrorOnNoFile": false});
+      try {
+        config = readConfig("/etc/wb-mqtt-dac.conf", {"logErrorOnNoFile": false});
+      } catch (err) {
+        log.warning("DAC: no config file");
+        return;
+      }
     }
 
     var channels_by_id = {};


### PR DESCRIPTION
Before:
```
INFO: [rule info] error running command callback for /bin/sh: TypeError: invalid base value
             duk_hobject_props.c:2000
             init /usr/share/wb-rules-system/rules/wb-mqtt-dac.js:24
             anon /usr/share/wb-rules-system/rules/wb-mqtt-dac.js:82
             anon /usr/share/wb-rules-system/scripts/lib.js:339 preventsyield
```

After:
```
WARNING: [rule warning] DAC: no config file
```