### PR TITLE
fix iio-device-num parsing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-dac (1.2.5) stable; urgency=medium
+
+  * Fix iio-device-num parsing
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Mon, 13 May 2024 11:22:13 +0300
+
 wb-mqtt-dac (1.2.4) stable; urgency=medium
 
   * Add homepage to deb package info. No functional changes

--- a/wb-mqtt-dac.js
+++ b/wb-mqtt-dac.js
@@ -82,7 +82,7 @@
           if (strParts.length == 2) {
             var path = strParts[0];
             var ofNodeName = strParts[1];
-            var num = path[path.length - '/of_node/name'.length - 1];
+            var num = path.match(/iio:device(\d+)/)[1];
             iioChannelOfNodeMap[num] = ofNodeName;
           }
         }


### PR DESCRIPTION
iio-девайсы парсились по длине строчки, и это всё-таки сломалось

игрался с wb8 - из `/sys/bus/iio/devices/iio:device10/` wb-rules брал номер 0